### PR TITLE
Feature predis adapter

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@ PHP Rate Limiting Library With [Token Bucket Algorithm][wiki]
 
 # Storage Adapters
 - [APCu](https://pecl.php.net/package/APCu)
-- [Redis](https://pecl.php.net/package/redis)
+- [Redis](https://pecl.php.net/package/redis) or [Predis](https://github.com/nrk/predis)
 
 # Example
 ````php
@@ -14,9 +14,11 @@ require 'vendor/autoload.php';
 use \Touhonoob\RateLimit\RateLimit;
 use \Touhonoob\RateLimit\Adapter\APC as RateLimitAdapterAPC;
 use \Touhonoob\RateLimit\Adapter\Redis as RateLimitAdapterRedis;
+use \Touhonoob\RateLimit\Adapter\Redis as RateLimitAdapterPredis;
 
 $adapter = new RateLimitAdapterAPC(); // Use APC as Storage
 // $adapter = new RateLimitAdapterRedis(); // Use Redis as Storage
+// $adapter = new RateLimitAdapterPredis(new \Predis\Client()); // Use Redis as Storage
 $rateLimit = new RateLimit("myratelimit", 100, 3600, $adapter); // 100 Requests / Hour
 
 $id = $_SERVER['REMOTE_ADDR']; // Use client IP as identity

--- a/composer.json
+++ b/composer.json
@@ -4,7 +4,8 @@
     "description": "Rate Limiting Library With Token Bucket Algorithm",
     "version": "1.2.0",
     "require": {
-        "php": ">=5.5"
+        "php": ">=5.5",
+        "jakub-onderka/php-parallel-lint": "^0.9.2"
     },
     "require-dev": {
         "phpunit/phpunit": "^4.6.6"
@@ -12,7 +13,8 @@
     "suggest": {
         "ext-redis": "^2.2",
         "ext-apc": "^4.0",
-        "ext-apcu": "^4.0"
+        "ext-apcu": "^4.0",
+        "predis/predis": "^1.1"
     },
     "license": "MIT",
     "authors": [
@@ -30,5 +32,8 @@
         "psr-4": {
             "Touhonoob\\RateLimit\\Tests\\": "tests/"
         }
+    },
+    "scripts": {
+        "lint": "@php ./vendor/bin/parallel-lint --exclude vendor/ ."
     }
 }

--- a/composer.json
+++ b/composer.json
@@ -4,17 +4,17 @@
     "description": "Rate Limiting Library With Token Bucket Algorithm",
     "version": "1.2.0",
     "require": {
-        "php": ">=5.5",
-        "jakub-onderka/php-parallel-lint": "^0.9.2"
+        "php": ">=5.5"
     },
     "require-dev": {
-        "phpunit/phpunit": "^4.6.6"
+        "phpunit/phpunit": "^4.6.6",
+        "jakub-onderka/php-parallel-lint": "^0.9.2",
+        "predis/predis": "^1.1"
     },
     "suggest": {
         "ext-redis": "^2.2",
         "ext-apc": "^4.0",
-        "ext-apcu": "^4.0",
-        "predis/predis": "^1.1"
+        "ext-apcu": "^4.0"
     },
     "license": "MIT",
     "authors": [

--- a/src/Adapter/Predis.php
+++ b/src/Adapter/Predis.php
@@ -1,0 +1,26 @@
+<?php
+
+namespace Touhonoob\RateLimit\Adapter;
+
+
+/**
+ * Predis adapter
+ */
+class Predis extends Redis
+{
+
+    /**
+     * @var \Predis\ClientInterface
+     */
+    protected $redis;
+
+    public function __construct(\Predis\ClientInterface $client)
+    {
+        $this->redis = $client;
+    }
+
+    public function set($key, $value, $ttl)
+    {
+        return $this->redis->set($key, $value, "ex", $ttl);
+    }
+}

--- a/tests/RateLimitTest.php
+++ b/tests/RateLimitTest.php
@@ -51,6 +51,16 @@ class RateLimitTest extends \PHPUnit_Framework_TestCase
         $this->check($adapter);
     }
 
+
+    public function testCheckPredisClient() {
+        if(!class_exists(\Predis\Client::class)) {
+            $this->markTestSkipped("no predis/predis support");
+        }
+        $predis = new \Predis\Client(); // assumes localhost:6379
+        $adapter = new \Touhonoob\RateLimit\Adapter\Predis($predis);
+        $this->check($adapter);
+    }
+
     private function check($adapter)
     {
         $ip = "127.0.0.1";


### PR DESCRIPTION
Add an adapter for predis support.

Predis is a PHP-only adapter for redis (doesn't rely on a php module/extension).

(Also adds parallel-lint to composer etc)