### PR TITLE
add test for memcache, fix constructor 

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,6 +5,7 @@ PHP Rate Limiting Library With [Token Bucket Algorithm][wiki]
 
 # Storage Adapters
 - [APCu](https://pecl.php.net/package/APCu)
+- [Memcached](http://php.net/manual/en/intro.memcached.php)
 - [Redis](https://pecl.php.net/package/redis)
 
 # Example
@@ -14,9 +15,11 @@ require 'vendor/autoload.php';
 use \Touhonoob\RateLimit\RateLimit;
 use \Touhonoob\RateLimit\Adapter\APC as RateLimitAdapterAPC;
 use \Touhonoob\RateLimit\Adapter\Redis as RateLimitAdapterRedis;
+use \Touhonoob\RateLimit\Adapter\Memcached as RateLimitAdapterMemcached;
 
 $adapter = new RateLimitAdapterAPC(); // Use APC as Storage
 // $adapter = new RateLimitAdapterRedis(); // Use Redis as Storage
+// $adapter = new RateLimitAdapterMemcached(['ip.address' => 'port']); // Use memcache for storage
 $rateLimit = new RateLimit("myratelimit", 100, 3600, $adapter); // 100 Requests / Hour
 
 $id = $_SERVER['REMOTE_ADDR']; // Use client IP as identity

--- a/src/Adapter/Memcached.php
+++ b/src/Adapter/Memcached.php
@@ -11,11 +11,10 @@ class Memcached extends \Touhonoob\RateLimit\Adapter
     protected $memcached;
 
     # https://github.com/websoftwares/Throttle/blob/master/src/Websoftwares/Storage/Memcached.php#L25
-    public function __construct(array $servers = [])
+    public function __construct(array $servers = ['127.0.0.1' => 11211])
     {
-        $servers = array_merge(['127.0.0.1' => 11211], $servers);
         $memcached = new \Memcached();
-        foreach($servers as $server => $port) {
+        foreach ($servers as $server => $port) {
             $memcached->addServer($server, $port);
         }
         $this->memcached = $memcached;
@@ -33,7 +32,8 @@ class Memcached extends \Touhonoob\RateLimit\Adapter
 
     public function exists($key)
     {
-        return (bool)$this->get($key);
+        return $this->get($key) !== false;
+
     }
 
     public function del($key)

--- a/tests/RateLimitTest.php
+++ b/tests/RateLimitTest.php
@@ -2,8 +2,8 @@
 
 namespace Touhonoob\RateLimit\Tests;
 
-use Touhonoob\RateLimit\RateLimit;
 use Touhonoob\RateLimit\Adapter;
+use Touhonoob\RateLimit\RateLimit;
 
 /**
  * @author Peter Chung <touhonoob@gmail.com>
@@ -42,6 +42,16 @@ class RateLimitTest extends \PHPUnit_Framework_TestCase
         $adapter = new \Touhonoob\RateLimit\Adapter\Redis();
         $this->check($adapter);
     }
+
+    public function testCheckMemcached()
+    {
+        if (!extension_loaded('memcached')) {
+            $this->markTestSkipped("memcached extension not installed");
+        }
+        $adapter = new \Touhonoob\RateLimit\Adapter\Memcached();
+        $this->check($adapter);
+    }
+
 
     public function testCheckRedisCustomClient()
     {


### PR DESCRIPTION
memcache adapter was missing a unit test
make it possible to not have localhost as a server to connect to.
fix issue with memcache confusing 0 as the key not existing.